### PR TITLE
feat: per-model TriggerDagRun after SQLMesh model (v0.9.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.14] - 2026-07-24
+
+### Added
+- **Per-model downstream DAG triggers** for clean separation of concerns:
+  - Config: `generation.model_triggers` map (`model FQN` → dag id / dict / `ModelTriggerConfig`)
+  - SQLMesh-native tags on the model:
+    - `trigger_dag:<dag_id>`
+    - `trigger_conf:<key>=<value>` (optional, repeatable)
+  - Wired in `create_tasks_in_dag` (runtime / COWM style) and static `dag_builder`
+  - Explicit config wins over tags; pipeline-level `trigger_dag_id` still works after leaves
+- Module `sqlmesh_dag_generator.triggers` with `ModelTriggerConfig`, `resolve_model_trigger`, etc.
+
 ## [0.9.13] - 2026-07-23
 
 ### Added

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,5 +1,43 @@
 # Usage Guide
 
+## Per-model downstream DAG triggers (≥0.9.14)
+
+Fire an Airflow DAG **only after a specific SQLMesh model** succeeds (not after the whole pipeline). Ideal for RT unload / notify steps.
+
+### Option A — SQLMesh tags (preferred for SoC)
+
+```sql
+MODEL (
+  name dwh.rt_fraud_da_set,
+  kind FULL,
+  cron '*/10 * * * *',
+  tags (
+    rt,
+    flink,
+    'trigger_dag:etl_rt_fraud_da_unload',
+    'trigger_conf:source=sqlmesh'
+  )
+);
+```
+
+### Option B — generator config
+
+```yaml
+generation:
+  model_triggers:
+    dwh.rt_fraud_da_set:
+      dag_id: etl_rt_fraud_da_unload
+      conf:
+        source: sqlmesh
+```
+
+Or kwargs: `SQLMeshDAGGenerator(..., model_triggers={"dwh.rt_fraud_da_set": "etl_rt_fraud_da_unload"})`.
+
+**Priority:** explicit `model_triggers` > tags.  
+**Pipeline-level** `trigger_dag_id` still runs after all leaf models (optional, separate).
+
+---
+
 ## 🚀 Quick Start
 
 ### Simplest Usage (Dynamic Mode - Default)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if requirements_file.exists():
 
 setup(
     name="sqlmesh-dag-generator",
-    version="0.9.13",
+    version="0.9.14",
     description="Open-source Airflow DAG generator for SQLMesh projects",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sqlmesh_dag_generator/__init__.py
+++ b/sqlmesh_dag_generator/__init__.py
@@ -2,11 +2,16 @@
 SQLMesh DAG Generator - Open Source Airflow Integration for SQLMesh
 """
 
-__version__ = "0.9.13"
+__version__ = "0.9.14"
 
 
 from sqlmesh_dag_generator.generator import SQLMeshDAGGenerator
 from sqlmesh_dag_generator.config import DAGGeneratorConfig, RecoveryConfig
+from sqlmesh_dag_generator.triggers import (
+    ModelTriggerConfig,
+    parse_trigger_from_tags,
+    resolve_model_trigger,
+)
 from sqlmesh_dag_generator.airflow_utils import (
     resolve_credentials,
     register_credential_resolver,
@@ -27,6 +32,9 @@ __all__ = [
     "SQLMeshDAGGenerator",
     "DAGGeneratorConfig",
     "RecoveryConfig",
+    "ModelTriggerConfig",
+    "parse_trigger_from_tags",
+    "resolve_model_trigger",
     "resolve_credentials",
     "register_credential_resolver",
     "CredentialResolver",

--- a/sqlmesh_dag_generator/config.py
+++ b/sqlmesh_dag_generator/config.py
@@ -2,9 +2,14 @@
 Configuration module for SQLMesh DAG Generator
 """
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Union
 from pathlib import Path
 import yaml
+
+from sqlmesh_dag_generator.triggers import (
+    ModelTriggerConfig,
+    normalize_model_triggers,
+)
 
 
 @dataclass
@@ -147,13 +152,23 @@ class GenerationConfig:
     # Resource management
     pool: Optional[str] = None  # Airflow pool for all tasks
     pool_slots: int = 1  # Number of pool slots per task
-    # Trigger downstream DAG after completion
+    # Trigger downstream DAG after completion of *all leaf* models (pipeline-level)
     trigger_dag_id: Optional[str] = None  # DAG to trigger on success
     trigger_dag_conf: Optional[Dict[str, Any]] = None  # Conf to pass to triggered DAG
+    # Per-model triggers (model FQN -> dag id / ModelTriggerConfig / dict).
+    # Also discoverable via SQLMesh tags: trigger_dag:<id>, trigger_conf:k=v
+    # Explicit map wins over tags. See sqlmesh_dag_generator.triggers.
+    model_triggers: Dict[str, Union[str, Dict[str, Any], ModelTriggerConfig]] = field(
+        default_factory=dict
+    )
     # Plan optimization options (for auto_replan_on_change)
     skip_backfill: bool = False  # Skip apply if backfill is required (use with CI/CD deploys)
     plan_only: bool = False  # Generate plan without applying (for review/dry-run)
     log_plan_details: bool = True  # Log detailed plan information (snapshots, intervals)
+
+    def __post_init__(self) -> None:
+        # Normalize model_triggers so consumers always see ModelTriggerConfig
+        self.model_triggers = normalize_model_triggers(self.model_triggers)  # type: ignore[assignment]
 
 
 @dataclass
@@ -176,7 +191,7 @@ class DAGGeneratorConfig:
         return cls(
             sqlmesh=SQLMeshConfig(**config_data.get("sqlmesh", {})),
             airflow=cls._build_airflow_config(config_data.get("airflow", {})),
-            generation=GenerationConfig(**config_data.get("generation", {})),
+            generation=cls._build_generation_config(config_data.get("generation", {})),
         )
 
     @classmethod
@@ -185,7 +200,7 @@ class DAGGeneratorConfig:
         return cls(
             sqlmesh=SQLMeshConfig(**config_dict.get("sqlmesh", {})),
             airflow=cls._build_airflow_config(config_dict.get("airflow", {})),
-            generation=GenerationConfig(**config_dict.get("generation", {})),
+            generation=cls._build_generation_config(config_dict.get("generation", {})),
         )
 
     @staticmethod
@@ -195,6 +210,13 @@ class DAGGeneratorConfig:
         recovery_dict = airflow_dict.pop("recovery", None) or {}
         airflow_dict["recovery"] = RecoveryConfig(**recovery_dict)
         return AirflowConfig(**airflow_dict)
+
+    @staticmethod
+    def _build_generation_config(config_dict: Dict[str, Any]) -> GenerationConfig:
+        """Build GenerationConfig (normalizes model_triggers)."""
+        gen = dict(config_dict or {})
+        # Leave model_triggers as-is; GenerationConfig.__post_init__ normalizes
+        return GenerationConfig(**gen)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert configuration to dictionary"""
@@ -255,6 +277,22 @@ class DAGGeneratorConfig:
                 "pool_slots": self.generation.pool_slots,
                 "trigger_dag_id": self.generation.trigger_dag_id,
                 "trigger_dag_conf": self.generation.trigger_dag_conf,
+                "model_triggers": {
+                    name: {
+                        "dag_id": getattr(cfg, "dag_id", cfg),
+                        "conf": getattr(cfg, "conf", {}) or {},
+                        "wait_for_completion": getattr(
+                            cfg, "wait_for_completion", False
+                        ),
+                        "reset_dag_run": getattr(cfg, "reset_dag_run", False),
+                        "poke_interval": getattr(cfg, "poke_interval", None),
+                    }
+                    if not isinstance(cfg, str)
+                    else {"dag_id": cfg, "conf": {}}
+                    for name, cfg in (
+                        self.generation.model_triggers or {}
+                    ).items()
+                },
                 "skip_backfill": self.generation.skip_backfill,
                 "plan_only": self.generation.plan_only,
                 "log_plan_details": self.generation.log_plan_details,

--- a/sqlmesh_dag_generator/dag_builder.py
+++ b/sqlmesh_dag_generator/dag_builder.py
@@ -111,7 +111,15 @@ class AirflowDAGBuilder:
                 "from kubernetes.client.models import V1EnvVar",
             ])
 
-        if self.config.generation.trigger_dag_id:
+        if (
+            self.config.generation.trigger_dag_id
+            or self.config.generation.model_triggers
+            or any(
+                str(t).lower().startswith("trigger_dag:")
+                for m in self.dag_structure.models.values()
+                for t in (m.tags or [])
+            )
+        ):
             compat_symbols.append("TriggerDagRunOperator")
 
         if self.config.generation.include_source_tables:
@@ -397,22 +405,62 @@ dag = DAG(
         if len(dep_lines) == 1:
             dep_lines.append("# No dependencies")
 
-        # Add trigger downstream DAG if configured
+        # Per-model triggers (tags and/or generation.model_triggers)
+        from sqlmesh_dag_generator.triggers import (
+            default_trigger_conf,
+            resolve_model_trigger,
+            trigger_task_id,
+        )
+
+        dep_lines.append("")
+        dep_lines.append("# Per-model downstream DAG triggers")
+        any_model_trigger = False
+        for model_name, model_info in self.dag_structure.models.items():
+            cfg = resolve_model_trigger(
+                model_name,
+                tags=model_info.tags,
+                model_triggers=self.config.generation.model_triggers,
+            )
+            if not cfg:
+                continue
+            any_model_trigger = True
+            conf = default_trigger_conf(model_name, cfg.conf)
+            model_task = model_info.get_task_id()
+            tid = trigger_task_id(cfg.dag_id, model_task)
+            dep_lines.append(
+                f'''{tid} = TriggerDagRunOperator(
+    task_id="{tid}",
+    trigger_dag_id="{cfg.dag_id}",
+    conf={repr(conf)},
+    wait_for_completion={cfg.wait_for_completion},
+    reset_dag_run={cfg.reset_dag_run},
+    dag=dag,
+)
+{model_task} >> {tid}'''
+            )
+        if not any_model_trigger:
+            dep_lines.append("# (none)")
+
+        # Pipeline-level trigger after all leaves (optional)
         if self.config.generation.trigger_dag_id:
             trigger_conf = repr(self.config.generation.trigger_dag_conf or {})
             dep_lines.append("")
-            dep_lines.append("# Trigger downstream DAG on completion")
+            dep_lines.append("# Trigger downstream DAG on pipeline completion")
             dep_lines.append(f'''trigger_downstream = TriggerDagRunOperator(
     task_id="trigger_{self.config.generation.trigger_dag_id}",
     trigger_dag_id="{self.config.generation.trigger_dag_id}",
     conf={trigger_conf},
     dag=dag,
 )''')
-            # Find leaf tasks and set them as upstream
             leaf_tasks = [
                 info.get_task_id()
                 for name, info in self.dag_structure.models.items()
-                if name not in {dep for m in self.dag_structure.models.values() for dep in m.dependencies}
+                if name
+                not in {
+                    dep
+                    for m in self.dag_structure.models.values()
+                    for dep in m.dependencies
+                }
             ]
             if leaf_tasks:
                 dep_lines.append(f"[{', '.join(leaf_tasks)}] >> trigger_downstream")

--- a/sqlmesh_dag_generator/generator.py
+++ b/sqlmesh_dag_generator/generator.py
@@ -193,6 +193,7 @@ class SQLMeshDAGGenerator:
                 pool_slots=kwargs.get("pool_slots", 1),
                 trigger_dag_id=kwargs.get("trigger_dag_id"),
                 trigger_dag_conf=kwargs.get("trigger_dag_conf"),
+                model_triggers=kwargs.get("model_triggers") or {},
                 # Plan optimization options
                 skip_backfill=kwargs.get("skip_backfill", False),
                 plan_only=kwargs.get("plan_only", False),
@@ -805,7 +806,16 @@ class SQLMeshDAGGenerator:
         Returns:
             Dictionary of created tasks {model_name: task}
         """
-        from sqlmesh_dag_generator.airflow_compat import EmptyOperator, PythonOperator
+        from sqlmesh_dag_generator.airflow_compat import (
+            EmptyOperator,
+            PythonOperator,
+            TriggerDagRunOperator,
+        )
+        from sqlmesh_dag_generator.triggers import (
+            default_trigger_conf,
+            resolve_model_trigger,
+            trigger_task_id,
+        )
 
         # Load models if not already loaded
         if not self.models:
@@ -1239,6 +1249,89 @@ class SQLMeshDAGGenerator:
                 replan_task >> current_task
             elif health_check_task and not current_task.upstream_task_ids:
                 health_check_task >> current_task
+
+        # Step 5: Per-model downstream DAG triggers (tags and/or model_triggers map)
+        # Fires only after *that* model succeeds — clean SoC for unload / notify DAGs.
+        if TriggerDagRunOperator is not None:
+            for model_name, model_info in target_models.items():
+                if model_name not in tasks:
+                    continue
+                trigger_cfg = resolve_model_trigger(
+                    model_name,
+                    tags=model_info.tags,
+                    model_triggers=self.config.generation.model_triggers,
+                )
+                if not trigger_cfg:
+                    continue
+                conf = default_trigger_conf(model_name, trigger_cfg.conf)
+                tid = trigger_task_id(trigger_cfg.dag_id, model_info.get_task_id())
+                op_kwargs = {
+                    "task_id": tid,
+                    "trigger_dag_id": trigger_cfg.dag_id,
+                    "conf": conf,
+                    "reset_dag_run": trigger_cfg.reset_dag_run,
+                    "wait_for_completion": trigger_cfg.wait_for_completion,
+                    "dag": dag,
+                }
+                if (
+                    trigger_cfg.wait_for_completion
+                    and trigger_cfg.poke_interval is not None
+                ):
+                    op_kwargs["poke_interval"] = trigger_cfg.poke_interval
+                try:
+                    trigger_op = TriggerDagRunOperator(**op_kwargs)
+                except TypeError:
+                    # Older Airflow may not accept all kwargs
+                    op_kwargs.pop("poke_interval", None)
+                    trigger_op = TriggerDagRunOperator(**op_kwargs)
+                tasks[model_name] >> trigger_op
+                tasks[tid] = trigger_op
+                logger.info(
+                    "Per-model trigger: %s -> DAG %s (task %s)",
+                    model_name,
+                    trigger_cfg.dag_id,
+                    tid,
+                )
+
+        # Step 6: Optional pipeline-level trigger after all leaf *model* tasks
+        if (
+            TriggerDagRunOperator is not None
+            and self.config.generation.trigger_dag_id
+        ):
+            leaf_names = []
+            if self.dag_structure:
+                leaf_names = [
+                    n
+                    for n in self.dag_structure.get_leaf_models()
+                    if n in tasks
+                ]
+            else:
+                deps = {
+                    d
+                    for info in target_models.values()
+                    for d in info.dependencies
+                }
+                leaf_names = [n for n in target_models if n not in deps and n in tasks]
+            if leaf_names:
+                conf = dict(self.config.generation.trigger_dag_conf or {})
+                conf.setdefault("source", "sqlmesh")
+                conf.setdefault("pipeline", self.config.airflow.dag_id)
+                pipeline_trigger = TriggerDagRunOperator(
+                    task_id=f"trigger_{self.config.generation.trigger_dag_id}",
+                    trigger_dag_id=self.config.generation.trigger_dag_id,
+                    conf=conf,
+                    dag=dag,
+                )
+                for name in leaf_names:
+                    tasks[name] >> pipeline_trigger
+                tasks[f"trigger_{self.config.generation.trigger_dag_id}"] = (
+                    pipeline_trigger
+                )
+                logger.info(
+                    "Pipeline-level trigger after leaves %s -> %s",
+                    leaf_names,
+                    self.config.generation.trigger_dag_id,
+                )
 
         # Return all tasks (both models and source tables)
         all_tasks = {**tasks, **source_table_tasks}

--- a/sqlmesh_dag_generator/triggers.py
+++ b/sqlmesh_dag_generator/triggers.py
@@ -1,0 +1,163 @@
+"""
+Per-model Airflow downstream DAG triggers.
+
+Resolution order (highest wins):
+  1. ``generation.model_triggers[model_name]`` explicit config
+  2. SQLMesh model tags:
+       - ``trigger_dag:<dag_id>``  (required for tag-based trigger)
+       - ``trigger_conf:<key>=<value>``  (optional, repeatable; values are strings)
+
+Example model tags (SQLMesh-native)::
+
+    tags (
+      rt,
+      flink,
+      'trigger_dag:etl_rt_fraud_da_unload',
+      'trigger_conf:source=sqlmesh'
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+
+TRIGGER_DAG_TAG_PREFIX = "trigger_dag:"
+TRIGGER_CONF_TAG_PREFIX = "trigger_conf:"
+
+
+@dataclass
+class ModelTriggerConfig:
+    """Downstream DAG to fire after a specific SQLMesh model task succeeds."""
+
+    dag_id: str
+    conf: Dict[str, Any] = field(default_factory=dict)
+    wait_for_completion: bool = False
+    reset_dag_run: bool = False
+    poke_interval: Optional[int] = None  # only used if wait_for_completion
+
+    def __post_init__(self) -> None:
+        if not self.dag_id or not str(self.dag_id).strip():
+            raise ValueError("ModelTriggerConfig.dag_id must be a non-empty string")
+        self.dag_id = str(self.dag_id).strip()
+        if self.conf is None:
+            self.conf = {}
+        if not isinstance(self.conf, dict):
+            raise ValueError("ModelTriggerConfig.conf must be a dict")
+
+
+def parse_trigger_from_tags(tags: Optional[Iterable[str]]) -> Optional[ModelTriggerConfig]:
+    """Parse ``trigger_dag:`` / ``trigger_conf:`` tags into a config, if present."""
+    if not tags:
+        return None
+
+    dag_id: Optional[str] = None
+    conf: Dict[str, Any] = {}
+
+    for raw in tags:
+        if raw is None:
+            continue
+        tag = str(raw).strip()
+        if not tag:
+            continue
+        lower = tag.lower()
+        if lower.startswith(TRIGGER_DAG_TAG_PREFIX):
+            value = tag[len(TRIGGER_DAG_TAG_PREFIX) :].strip()
+            if value:
+                dag_id = value
+            continue
+        if lower.startswith(TRIGGER_CONF_TAG_PREFIX):
+            rest = tag[len(TRIGGER_CONF_TAG_PREFIX) :]
+            if "=" not in rest:
+                continue
+            key, value = rest.split("=", 1)
+            key = key.strip()
+            if key:
+                conf[key] = value.strip()
+
+    if not dag_id:
+        return None
+    return ModelTriggerConfig(dag_id=dag_id, conf=conf)
+
+
+def _coerce_trigger_entry(entry: Any) -> ModelTriggerConfig:
+    if isinstance(entry, ModelTriggerConfig):
+        return entry
+    if isinstance(entry, str):
+        return ModelTriggerConfig(dag_id=entry)
+    if isinstance(entry, Mapping):
+        return ModelTriggerConfig(
+            dag_id=str(entry.get("dag_id") or entry.get("trigger_dag_id") or ""),
+            conf=dict(entry.get("conf") or {}),
+            wait_for_completion=bool(entry.get("wait_for_completion", False)),
+            reset_dag_run=bool(entry.get("reset_dag_run", False)),
+            poke_interval=entry.get("poke_interval"),
+        )
+    raise TypeError(
+        f"Unsupported model_triggers entry type: {type(entry)!r} "
+        f"(expected str, dict, or ModelTriggerConfig)"
+    )
+
+
+def normalize_model_triggers(
+    raw: Optional[Mapping[str, Any]],
+) -> Dict[str, ModelTriggerConfig]:
+    """Normalize YAML/dict model_triggers map to ModelTriggerConfig values."""
+    if not raw:
+        return {}
+    out: Dict[str, ModelTriggerConfig] = {}
+    for model_name, entry in raw.items():
+        if not model_name:
+            continue
+        out[str(model_name)] = _coerce_trigger_entry(entry)
+    return out
+
+
+def resolve_model_trigger(
+    model_name: str,
+    tags: Optional[Iterable[str]] = None,
+    model_triggers: Optional[Mapping[str, Any]] = None,
+) -> Optional[ModelTriggerConfig]:
+    """
+    Resolve trigger for one model.
+
+    Explicit ``model_triggers[model_name]`` wins over tags.
+    """
+    normalized = normalize_model_triggers(model_triggers)
+    if model_name in normalized:
+        return normalized[model_name]
+
+    # FQN / short-name flexibility
+    short = model_name.split(".")[-1]
+    for key, cfg in normalized.items():
+        if key == model_name or key == short:
+            return cfg
+        if key.endswith(f".{short}") and model_name.endswith(f".{short}"):
+            return cfg
+
+    return parse_trigger_from_tags(tags)
+
+
+def trigger_task_id(dag_id: str, model_task_id: str) -> str:
+    """Stable Airflow task_id for a per-model trigger operator."""
+    safe_dag = (
+        dag_id.replace(".", "_").replace("-", "_").replace(" ", "_").strip("_")
+    )
+    base = f"trigger_{safe_dag}__after_{model_task_id}"
+    if len(base) <= 200:
+        return base
+    return f"trigger_{safe_dag}_{abs(hash(model_task_id)) % 10_000_000}"
+
+
+def default_trigger_conf(
+    model_name: str,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    conf: Dict[str, Any] = {
+        "source": "sqlmesh",
+        "model": model_name,
+    }
+    if extra:
+        conf.update(dict(extra))
+    return conf

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,114 @@
+"""Tests for per-model DAG trigger resolution."""
+
+from sqlmesh_dag_generator.config import GenerationConfig, DAGGeneratorConfig
+from sqlmesh_dag_generator.triggers import (
+    ModelTriggerConfig,
+    default_trigger_conf,
+    normalize_model_triggers,
+    parse_trigger_from_tags,
+    resolve_model_trigger,
+    trigger_task_id,
+)
+
+
+def test_parse_trigger_from_tags_basic():
+    cfg = parse_trigger_from_tags(
+        ["rt", "flink", "trigger_dag:etl_rt_fraud_da_unload"]
+    )
+    assert cfg is not None
+    assert cfg.dag_id == "etl_rt_fraud_da_unload"
+    assert cfg.conf == {}
+
+
+def test_parse_trigger_conf_tags():
+    cfg = parse_trigger_from_tags(
+        [
+            "trigger_dag:etl_rt_fraud_da_unload",
+            "trigger_conf:source=sqlmesh",
+            "trigger_conf:bucket=stg-carrier-quality-rt-alerts",
+        ]
+    )
+    assert cfg is not None
+    assert cfg.dag_id == "etl_rt_fraud_da_unload"
+    assert cfg.conf["source"] == "sqlmesh"
+    assert cfg.conf["bucket"] == "stg-carrier-quality-rt-alerts"
+
+
+def test_parse_no_trigger_tag():
+    assert parse_trigger_from_tags(["rt", "fraud"]) is None
+    assert parse_trigger_from_tags(None) is None
+
+
+def test_explicit_config_wins_over_tags():
+    cfg = resolve_model_trigger(
+        "dwh.rt_fraud_da_set",
+        tags=["trigger_dag:from_tag"],
+        model_triggers={
+            "dwh.rt_fraud_da_set": {
+                "dag_id": "from_config",
+                "conf": {"x": 1},
+            }
+        },
+    )
+    assert cfg is not None
+    assert cfg.dag_id == "from_config"
+    assert cfg.conf == {"x": 1}
+
+
+def test_tags_used_when_no_explicit():
+    cfg = resolve_model_trigger(
+        "dwh.rt_fraud_da_set",
+        tags=["trigger_dag:from_tag"],
+        model_triggers={},
+    )
+    assert cfg is not None
+    assert cfg.dag_id == "from_tag"
+
+
+def test_normalize_string_entry():
+    n = normalize_model_triggers({"dwh.foo": "bar_dag"})
+    assert n["dwh.foo"].dag_id == "bar_dag"
+
+
+def test_generation_config_normalizes_model_triggers():
+    gen = GenerationConfig(
+        model_triggers={
+            "dwh.rt_fraud_da_set": "etl_rt_fraud_da_unload",
+        }
+    )
+    assert isinstance(gen.model_triggers["dwh.rt_fraud_da_set"], ModelTriggerConfig)
+    assert gen.model_triggers["dwh.rt_fraud_da_set"].dag_id == "etl_rt_fraud_da_unload"
+
+
+def test_from_dict_model_triggers():
+    cfg = DAGGeneratorConfig.from_dict(
+        {
+            "sqlmesh": {"project_path": "/tmp/p"},
+            "airflow": {"dag_id": "test"},
+            "generation": {
+                "model_triggers": {
+                    "dwh.rt_fraud_da_set": {
+                        "dag_id": "etl_rt_fraud_da_unload",
+                        "conf": {"source": "sqlmesh"},
+                    }
+                }
+            },
+        }
+    )
+    mt = cfg.generation.model_triggers["dwh.rt_fraud_da_set"]
+    assert mt.dag_id == "etl_rt_fraud_da_unload"
+    assert mt.conf["source"] == "sqlmesh"
+
+
+def test_default_trigger_conf_merges():
+    conf = default_trigger_conf("dwh.rt_fraud_da_set", {"bucket": "b"})
+    assert conf["source"] == "sqlmesh"
+    assert conf["model"] == "dwh.rt_fraud_da_set"
+    assert conf["bucket"] == "b"
+
+
+def test_trigger_task_id_stable():
+    a = trigger_task_id("etl_rt_fraud_da_unload", "sqlmesh_dwh_rt_fraud_da_set")
+    b = trigger_task_id("etl_rt_fraud_da_unload", "sqlmesh_dwh_rt_fraud_da_set")
+    assert a == b
+    assert "etl_rt_fraud_da_unload" in a


### PR DESCRIPTION
## Summary
- Per-model Airflow `TriggerDagRunOperator` after a **specific** SQLMesh model task succeeds
- Discoverable via SQLMesh tags (`trigger_dag:<dag_id>`, `trigger_conf:k=v`) or `generation.model_triggers`
- Wired in `create_tasks_in_dag` (runtime) and static `dag_builder`
- Pipeline-level `trigger_dag_id` unchanged (fires after leaf models)
- Tests: `tests/test_triggers.py`

## Use case
RT fraud DA: model `dwh.rt_fraud_da_set` tags → `etl_rt_fraud_da_unload` (S3 for Flink) without coupling to the full DWH graph.

## Test plan
- [x] `pytest tests/test_triggers.py tests/test_config.py`
- [ ] Release/publish `0.9.14` to package index used by COWM STG