### PR TITLE
feat: skip_if_not_due for mixed-cadence DAGs (v0.9.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-10
+
+### Added
+- **`generation.skip_if_not_due` (default `True`)** for mixed-cadence DAGs:
+  when the DAG schedule is the minimum model interval (e.g. `*/5`) but the project
+  also has hourly/daily models, coarser model tasks **return early** with
+  `{"status": "skipped", "reason": "not_due"}` **before** loading SQLMesh
+  `Context` (Context alone often costs 30–50s per task on a no-op tick).
+- Helpers in `sqlmesh_dag_generator.utils` (also re-exported from package root):
+  `should_skip_model_for_tick`, `interval_end_matches_cron`, `not_due_skip_result`.
+- Wired in `create_tasks_in_dag` (runtime), static Python tasks, and dynamic DAG
+  generation. Depends on `croniter` (already common via Airflow).
+
+### Why
+Auto-schedule correctly picks the shortest interval, but every tick still scheduled
+*all* model tasks. Coarser models then either froze state (old bug, fixed by
+omitting start/end) or paid full Context cost for NOTHING_TO_DO. Early skip keeps
+the 5-minute wall-clock budget for models that are actually due.
+
+### Config
+```yaml
+generation:
+  skip_if_not_due: true   # default; set false only for break-glass debugging
+```
+
 ## [0.9.14] - 2026-07-24
 
 ### Added

--- a/docs/AUTO_SCHEDULING.md
+++ b/docs/AUTO_SCHEDULING.md
@@ -44,6 +44,44 @@ recommended_schedule = generator.get_recommended_schedule()
 #          "@daily" if all models are daily or longer
 ```
 
+## ⚠️ Mixed cadences on one DAG (important)
+
+Auto-schedule sets the DAG to the **shortest** model interval. That means:
+
+| Model cron | DAG tick (`*/5`) | Behaviour with `skip_if_not_due=True` (default) |
+| --- | --- | --- |
+| `*/5 * * * *` | every 5 min | **Runs** (loads Context, `ctx.run`) |
+| `0 * * * *` (hourly) | every 5 min | **Skipped** until `data_interval_end` is on the hour |
+| daily | every 5 min | **Skipped** until the model’s own cron tick |
+
+Skip happens **before** `sqlmesh.Context(...)` so coarser models do not burn
+30–50s of worker time on no-op ticks (and do not push a 5-minute pipeline past
+its schedule window under `max_active_runs=1`).
+
+```python
+generator = SQLMeshDAGGenerator(
+    sqlmesh_project_path="/path/to/project",
+    gateway="prod",
+    auto_replan_on_change=False,
+    # skip_if_not_due=True  # default since 0.9.15
+)
+```
+
+Set `skip_if_not_due=False` only when debugging “why didn’t this hourly model
+run?” — it restores the old always-run behaviour (expensive no-ops).
+
+XCom when skipped:
+
+```python
+{"status": "skipped", "reason": "not_due", "model": "...", "cron": "0 * * * *"}
+```
+
+### Optional: split DAGs by cadence
+
+If the hot path is still too heavy (e.g. many true 5-minute models), split into
+separate DAGs with `include_models` / tags rather than one mega-DAG. Early skip
+is the right default for mixed projects; split is the next step for scale.
+
 ## 🎯 How It Works
 
 ### 1. SQLMesh Models Define Intervals

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@
 sqlmesh>=0.228.0
 apache-airflow>=2.4.0
 pyyaml>=5.4.0
+# Used for mixed-cadence skip_if_not_due (also pulled in by Airflow)
+croniter>=1.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if requirements_file.exists():
 
 setup(
     name="sqlmesh-dag-generator",
-    version="0.9.14",
+    version="0.9.15",
     description="Open-source Airflow DAG generator for SQLMesh projects",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sqlmesh_dag_generator/__init__.py
+++ b/sqlmesh_dag_generator/__init__.py
@@ -2,7 +2,7 @@
 SQLMesh DAG Generator - Open Source Airflow Integration for SQLMesh
 """
 
-__version__ = "0.9.14"
+__version__ = "0.9.15"
 
 
 from sqlmesh_dag_generator.generator import SQLMeshDAGGenerator
@@ -27,6 +27,11 @@ from sqlmesh_dag_generator.airflow_compat import (
     dag_schedule_kwargs,
     is_airflow_3,
 )
+from sqlmesh_dag_generator.utils import (
+    interval_end_matches_cron,
+    not_due_skip_result,
+    should_skip_model_for_tick,
+)
 
 __all__ = [
     "SQLMeshDAGGenerator",
@@ -47,6 +52,10 @@ __all__ = [
     "Variable",
     "dag_schedule_kwargs",
     "is_airflow_3",
+    # Mixed-cadence due-skip helpers
+    "interval_end_matches_cron",
+    "not_due_skip_result",
+    "should_skip_model_for_tick",
 ]
 
 

--- a/sqlmesh_dag_generator/config.py
+++ b/sqlmesh_dag_generator/config.py
@@ -165,6 +165,10 @@ class GenerationConfig:
     skip_backfill: bool = False  # Skip apply if backfill is required (use with CI/CD deploys)
     plan_only: bool = False  # Generate plan without applying (for review/dry-run)
     log_plan_details: bool = True  # Log detailed plan information (snapshots, intervals)
+    # Mixed-cadence DAGs (schedule = min model interval): coarser models still get a
+    # task every tick. When True (default), those tasks return skipped/not_due *before*
+    # loading SQLMesh Context — avoids tens of seconds of no-op cost per tick.
+    skip_if_not_due: bool = True
 
     def __post_init__(self) -> None:
         # Normalize model_triggers so consumers always see ModelTriggerConfig
@@ -296,6 +300,7 @@ class DAGGeneratorConfig:
                 "skip_backfill": self.generation.skip_backfill,
                 "plan_only": self.generation.plan_only,
                 "log_plan_details": self.generation.log_plan_details,
+                "skip_if_not_due": self.generation.skip_if_not_due,
             },
         }
 

--- a/sqlmesh_dag_generator/dag_builder.py
+++ b/sqlmesh_dag_generator/dag_builder.py
@@ -155,11 +155,14 @@ class AirflowDAGBuilder:
 
     def _build_config(self) -> str:
         """Build configuration section"""
+        expected_interval_minutes = self._get_expected_interval_minutes()
         return dedent(f'''
             # SQLMesh Configuration
             SQLMESH_PROJECT_PATH = "{self.config.sqlmesh.project_path}"
             SQLMESH_ENVIRONMENT = "{self.config.sqlmesh.environment}"
             SQLMESH_GATEWAY = {f'"{self.config.sqlmesh.gateway}"' if self.config.sqlmesh.gateway else 'None'}
+            EXPECTED_INTERVAL_MINUTES = {expected_interval_minutes if expected_interval_minutes is not None else "None"}
+            SKIP_IF_NOT_DUE = {self.config.generation.skip_if_not_due}
         ''').strip()
 
     def _build_dag_definition(self) -> str:
@@ -266,25 +269,47 @@ dag = DAG(
         # Escape model name for use in strings
         model_name_escaped = model_info.name.replace('"', '\\"')
 
+        model_cron = (model_info.cron or "").replace('"', '\\"')
+        model_interval_min = (
+            get_interval_frequency_minutes(model_info.interval_unit)
+            if model_info.interval_unit is not None
+            else "None"
+        )
+        skip_if_not_due = self.config.generation.skip_if_not_due
+
         # Build the execution function
         func_def = f'''def {function_name}(**context):
     """Execute SQLMesh model: {model_name_escaped}"""
+    from sqlmesh_dag_generator.utils import (
+        not_due_skip_result,
+        should_skip_model_for_tick,
+    )
+
+    # Get time interval from Airflow context (Airflow 2.2+)
+    start = context.get('data_interval_start') or context.get('execution_date')
+    end = context.get('data_interval_end') or context.get('execution_date')
+
+    if should_skip_model_for_tick(
+        cron_expr="{model_cron}" or None,
+        model_interval_minutes={model_interval_min},
+        dag_tick_minutes=EXPECTED_INTERVAL_MINUTES,
+        data_interval_end=end,
+        skip_if_not_due={skip_if_not_due},
+    ):
+        logger.info("Skipping {model_name_escaped}: not due at %s", end)
+        return not_due_skip_result("{model_name_escaped}", "{model_cron}" or None)
+
     logger.info("Executing SQLMesh model: {model_name_escaped}")
-    
+
     # Load SQLMesh context
     ctx = Context(
         paths=SQLMESH_PROJECT_PATH,
         gateway=SQLMESH_GATEWAY,
     )
-    
-    # Get time interval from Airflow context (Airflow 2.2+)
-    # Use data_interval for proper incremental model handling
-    start = context.get('data_interval_start') or context.get('execution_date')
-    end = context.get('data_interval_end') or context.get('execution_date')
-    
+
     # Run the specific model
     logger.info(f"Running model {model_name_escaped} for interval {{start}} to {{end}}")
-    
+
     # Use SQLMesh's run method with model selection
     result = ctx.run(
         environment=SQLMESH_ENVIRONMENT,
@@ -292,7 +317,7 @@ dag = DAG(
         end=end,
         select_models=["{model_name_escaped}"],
     )
-    
+
     logger.info(f"Model {model_name_escaped} completed successfully")
     return result'''
 
@@ -531,6 +556,7 @@ RECOVERY_MAX_INTERVALS = {self.config.airflow.recovery.max_intervals}
 RECOVERY_FAIL_ON_EXCESS_GAP = {self.config.airflow.recovery.fail_on_excess_gap}
 EXPECTED_INTERVAL_MINUTES = {expected_interval_minutes if expected_interval_minutes is not None else 'None'}
 HAS_SUBHOURLY_INCREMENTAL = {has_subhourly_incremental}
+SKIP_IF_NOT_DUE = {self.config.generation.skip_if_not_due}
 
 logger.info(f"SQLMesh Project Path: {{SQLMESH_PROJECT_PATH}}")
 logger.info(f"SQLMesh Environment: {{SQLMESH_ENVIRONMENT}}")
@@ -628,10 +654,21 @@ try:
                 deps.append(str(dep.name))
             else:
                 deps.append(str(dep))
+        _iu = getattr(model, "interval_unit", None)
+        _iu_name = str(_iu).upper().replace("INTERVALUNIT.", "") if _iu is not None else None
+        _freq = {{
+            "MINUTE": 1, "FIVE_MINUTE": 5, "TEN_MINUTE": 10,
+            "QUARTER_HOUR": 15, "FIFTEEN_MINUTE": 15,
+            "HALF_HOUR": 30, "THIRTY_MINUTE": 30, "HOUR": 60,
+            "DAY": 1440, "WEEK": 10080, "MONTH": 43200,
+            "QUARTER": 129600, "YEAR": 525600,
+        }}
         discovered_models[model_name] = {{
             "fqn": model.fqn,
             "name": str(model.name),
             "dependencies": deps,
+            "cron": getattr(model, "cron", None),
+            "interval_minutes": _freq.get(_iu_name) if _iu_name else None,
         }}
     
     logger.info(f"✓ Discovered {{{{len(discovered_models)}}}} SQLMesh models")
@@ -788,10 +825,31 @@ with DAG(
         task_id = task_id.strip("_")
         
         # Create callable for this model
-        def make_callable(model_fqn, model_display_name):
+        def make_callable(model_fqn, model_display_name, model_cron, model_interval_minutes):
             """Factory function to create model-specific callable"""
             def execute_model(**context):
                 """Execute SQLMesh model"""
+                from sqlmesh_dag_generator.utils import (
+                    not_due_skip_result,
+                    should_skip_model_for_tick,
+                )
+
+                start = context.get('data_interval_start') or context.get('execution_date')
+                end = context.get('data_interval_end') or context.get('execution_date')
+
+                if should_skip_model_for_tick(
+                    cron_expr=model_cron,
+                    model_interval_minutes=model_interval_minutes,
+                    dag_tick_minutes=EXPECTED_INTERVAL_MINUTES,
+                    data_interval_end=end,
+                    skip_if_not_due=SKIP_IF_NOT_DUE,
+                ):
+                    logger.info(
+                        f"Skipping {{model_display_name}}: not due at {{end}} "
+                        f"(cron={{model_cron}}, model={{model_interval_minutes}}min)"
+                    )
+                    return not_due_skip_result(model_fqn, model_cron)
+
                 logger.info(f"Executing SQLMesh model: {{model_display_name}}")
                 
                 try:
@@ -800,12 +858,6 @@ with DAG(
                         paths=SQLMESH_PROJECT_PATH,
                         gateway=SQLMESH_GATEWAY,
                     )
-                    
-                    # Get time interval (Airflow 2.2+)
-                    # data_interval_start/end provides correct time range for incremental models
-                    # Falls back to execution_date for backward compatibility with Airflow < 2.2
-                    start = context.get('data_interval_start') or context.get('execution_date')
-                    end = context.get('data_interval_end') or context.get('execution_date')
                     
                     logger.info(f"Running model {{model_display_name}} for interval {{start}} to {{end}}")
                     
@@ -837,7 +889,12 @@ with DAG(
         # Create PythonOperator
         task = PythonOperator(
             task_id=task_id,
-            python_callable=make_callable(model_info["fqn"], model_info["name"]),
+            python_callable=make_callable(
+                model_info["fqn"],
+                model_info["name"],
+                model_info.get("cron"),
+                model_info.get("interval_minutes"),
+            ),
         )
         
         tasks[model_name] = task

--- a/sqlmesh_dag_generator/generator.py
+++ b/sqlmesh_dag_generator/generator.py
@@ -14,7 +14,12 @@ from sqlmesh_dag_generator.config import DAGGeneratorConfig, SQLMeshConfig, Airf
 from sqlmesh_dag_generator.models import SQLMeshModelInfo, DAGStructure
 from sqlmesh_dag_generator.dag_builder import AirflowDAGBuilder
 from sqlmesh_dag_generator.security import install_credential_filter, validate_connection_security
-from sqlmesh_dag_generator.utils import get_interval_frequency_minutes, sanitize_task_id
+from sqlmesh_dag_generator.utils import (
+    get_interval_frequency_minutes,
+    not_due_skip_result,
+    sanitize_task_id,
+    should_skip_model_for_tick,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +203,7 @@ class SQLMeshDAGGenerator:
                 skip_backfill=kwargs.get("skip_backfill", False),
                 plan_only=kwargs.get("plan_only", False),
                 log_plan_details=kwargs.get("log_plan_details", True),
+                skip_if_not_due=kwargs.get("skip_if_not_due", True),
             )
 
             self.config = DAGGeneratorConfig(
@@ -1069,8 +1075,36 @@ class SQLMeshDAGGenerator:
             task_id = model_info.get_task_id()
 
             # Create the execution function
-            def make_callable(m_name, m_fqn, m_interval_minutes=None):
+            def make_callable(m_name, m_fqn, m_interval_minutes=None, m_cron=None):
                 def execute_model(**context):
+                    # Get time interval (Airflow 2.2+)
+                    # data_interval_start/end provides correct time range for incremental models
+                    # Falls back to execution_date for backward compatibility with Airflow < 2.2
+                    start = context.get('data_interval_start') or context.get('execution_date')
+                    end = context.get('data_interval_end') or context.get('execution_date')
+
+                    # Mixed-cadence: skip coarser models when this tick is not their cron
+                    # *before* loading SQLMesh Context (Context alone is expensive).
+                    if should_skip_model_for_tick(
+                        cron_expr=m_cron,
+                        model_interval_minutes=m_interval_minutes,
+                        dag_tick_minutes=expected_interval_minutes,
+                        data_interval_end=end,
+                        skip_if_not_due=self.config.generation.skip_if_not_due,
+                    ):
+                        logger.info(
+                            "Skipping %s: not due at data_interval_end=%s "
+                            "(cron=%s, model=%smin, dag_tick=%smin)",
+                            m_fqn,
+                            end,
+                            m_cron,
+                            m_interval_minutes,
+                            expected_interval_minutes,
+                        )
+                        if not self.config.generation.return_value:
+                            return None
+                        return not_due_skip_result(m_fqn, m_cron)
+
                     from sqlmesh import Context
 
                     # Build context kwargs - use merged config if available
@@ -1091,12 +1125,6 @@ class SQLMeshDAGGenerator:
                     # Load fresh context with runtime connections
                     run_ctx = Context(**context_kwargs)
 
-                    # Get time interval (Airflow 2.2+)
-                    # data_interval_start/end provides correct time range for incremental models
-                    # Falls back to execution_date for backward compatibility with Airflow < 2.2
-                    start = context.get('data_interval_start') or context.get('execution_date')
-                    end = context.get('data_interval_end') or context.get('execution_date')
-
                     # When this model's interval is COARSER than the DAG tick,
                     # the tick's data_interval window (e.g. 5 minutes on a mixed
                     # sub-hourly + hourly project) spans no full model interval.
@@ -1104,6 +1132,7 @@ class SQLMeshDAGGenerator:
                     # silently freezes while the task still reports success.
                     # In that case omit start/end so SQLMesh selects the correct
                     # interval(s) from the model's own cron instead.
+                    # (Only reached when the model *is* due, or skip_if_not_due=False.)
                     if (
                         m_interval_minutes
                         and expected_interval_minutes
@@ -1216,6 +1245,7 @@ class SQLMeshDAGGenerator:
                     get_interval_frequency_minutes(model_info.interval_unit)
                     if model_info.interval_unit is not None
                     else None,
+                    model_info.cron,
                 ),
                 dag=dag,
             )

--- a/sqlmesh_dag_generator/utils.py
+++ b/sqlmesh_dag_generator/utils.py
@@ -1,9 +1,13 @@
 """
 Utility functions for SQLMesh DAG Generator
 """
+import logging
 import re
-from typing import List, Optional, Tuple, Any
+from datetime import datetime, timedelta
+from typing import List, Optional, Tuple, Any, Dict
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def interval_to_cron(interval_unit: Optional[Any]) -> Optional[str]:
@@ -156,11 +160,103 @@ def parse_cron_schedule(cron: Optional[str]) -> Optional[str]:
         return None
 
     # Basic validation - cron should have 5 or 6 parts
-    parts = cron.strip().split()
+    # Airflow/SQLMesh also use aliases like @hourly / @daily (handled by croniter).
+    raw = cron.strip()
+    if raw.startswith("@"):
+        return raw
+
+    parts = raw.split()
     if len(parts) not in [5, 6]:
         return None
 
-    return cron
+    return raw
+
+
+def interval_end_matches_cron(cron_expr: str, data_interval_end: datetime) -> bool:
+    """
+    True when ``data_interval_end`` is an exact fire time of ``cron_expr``.
+
+    Used for mixed-cadence DAGs: schedule is the *minimum* model interval (e.g.
+    ``*/5``), but coarser models (hourly/daily) should only *work* on their own
+    cron ticks. Requires ``croniter`` (shipped with Airflow).
+    """
+    if not cron_expr or data_interval_end is None:
+        return True
+    try:
+        from croniter import croniter
+    except ImportError:  # pragma: no cover
+        logger.warning(
+            "croniter is not installed; cannot evaluate cron due-ness for %r",
+            cron_expr,
+        )
+        return True
+
+    end = data_interval_end
+    probe = end - timedelta(seconds=1)
+    nxt = croniter(cron_expr, probe).get_next(type(end))
+    return nxt == end
+
+
+def interval_end_matches_minutes(
+    interval_minutes: int, data_interval_end: datetime
+) -> bool:
+    """
+    Fallback due-check when a model has interval_unit but no cron string.
+
+    Aligns to wall-clock boundaries (UTC if tz-aware): every N minutes from the
+    hour for N < 60, on the hour for N == 60, midnight for N >= 1440.
+    """
+    if not interval_minutes or data_interval_end is None:
+        return True
+    end = data_interval_end
+    if interval_minutes >= 1440:
+        return end.hour == 0 and end.minute == 0 and end.second == 0
+    if interval_minutes >= 60:
+        # Multi-hour: require minute=0 and hour % (N/60) == 0
+        hours = max(1, interval_minutes // 60)
+        return end.minute == 0 and end.second == 0 and (end.hour % hours) == 0
+    return end.second == 0 and (end.minute % interval_minutes) == 0
+
+
+def should_skip_model_for_tick(
+    *,
+    cron_expr: Optional[str] = None,
+    model_interval_minutes: Optional[int] = None,
+    dag_tick_minutes: Optional[int] = None,
+    data_interval_end: Optional[datetime] = None,
+    skip_if_not_due: bool = True,
+) -> bool:
+    """
+    Whether a model task should no-op on this Airflow DAG tick.
+
+    When the DAG schedule is the min model interval (auto_schedule), coarser
+    models still get a task every tick. Running them loads SQLMesh ``Context``
+    (~tens of seconds) even when SQLMesh would do nothing. Skip those ticks
+    *before* Context load when the model is not due.
+    """
+    if not skip_if_not_due:
+        return False
+    if data_interval_end is None:
+        return False
+    if not model_interval_minutes or not dag_tick_minutes:
+        return False
+    # Same cadence as the DAG (or finer): always run on every tick.
+    if model_interval_minutes <= dag_tick_minutes:
+        return False
+
+    if cron_expr:
+        return not interval_end_matches_cron(cron_expr, data_interval_end)
+    return not interval_end_matches_minutes(model_interval_minutes, data_interval_end)
+
+
+def not_due_skip_result(model_fqn: str, cron_expr: Optional[str] = None) -> Dict[str, Any]:
+    """XCom-friendly payload when a model is skipped as not due."""
+    return {
+        "status": "skipped",
+        "reason": "not_due",
+        "model": model_fqn,
+        "cron": cron_expr,
+    }
 
 
 def detect_circular_dependencies(dependencies: dict) -> Optional[List[str]]:

--- a/tests/test_skip_if_not_due.py
+++ b/tests/test_skip_if_not_due.py
@@ -1,0 +1,87 @@
+"""Tests for mixed-cadence skip_if_not_due helpers."""
+from datetime import datetime, timezone
+
+from sqlmesh_dag_generator.config import GenerationConfig
+from sqlmesh_dag_generator.utils import (
+    interval_end_matches_cron,
+    interval_end_matches_minutes,
+    not_due_skip_result,
+    should_skip_model_for_tick,
+)
+
+
+def test_generation_config_skip_if_not_due_default():
+    assert GenerationConfig().skip_if_not_due is True
+
+
+def test_interval_end_matches_cron():
+    end_5 = datetime(2026, 8, 10, 12, 5, tzinfo=timezone.utc)
+    end_hour = datetime(2026, 8, 10, 13, 0, tzinfo=timezone.utc)
+    end_off = datetime(2026, 8, 10, 12, 7, tzinfo=timezone.utc)
+
+    assert interval_end_matches_cron("*/5 * * * *", end_5)
+    assert not interval_end_matches_cron("0 * * * *", end_5)
+    assert interval_end_matches_cron("0 * * * *", end_hour)
+    assert interval_end_matches_cron("@hourly", end_hour)
+    assert not interval_end_matches_cron("*/5 * * * *", end_off)
+
+
+def test_interval_end_matches_minutes_fallback():
+    end = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+    mid = datetime(2026, 8, 10, 12, 5, tzinfo=timezone.utc)
+    assert interval_end_matches_minutes(60, end)
+    assert not interval_end_matches_minutes(60, mid)
+    assert interval_end_matches_minutes(5, mid)
+    assert not interval_end_matches_minutes(5, datetime(2026, 8, 10, 12, 7, tzinfo=timezone.utc))
+
+
+def test_should_skip_same_cadence_never_skips():
+    end = datetime(2026, 8, 10, 12, 7, tzinfo=timezone.utc)
+    assert not should_skip_model_for_tick(
+        cron_expr="*/5 * * * *",
+        model_interval_minutes=5,
+        dag_tick_minutes=5,
+        data_interval_end=end,
+        skip_if_not_due=True,
+    )
+
+
+def test_should_skip_coarser_when_not_due():
+    end = datetime(2026, 8, 10, 12, 5, tzinfo=timezone.utc)
+    assert should_skip_model_for_tick(
+        cron_expr="0 * * * *",
+        model_interval_minutes=60,
+        dag_tick_minutes=5,
+        data_interval_end=end,
+        skip_if_not_due=True,
+    )
+
+
+def test_should_not_skip_coarser_when_due():
+    end = datetime(2026, 8, 10, 13, 0, tzinfo=timezone.utc)
+    assert not should_skip_model_for_tick(
+        cron_expr="0 * * * *",
+        model_interval_minutes=60,
+        dag_tick_minutes=5,
+        data_interval_end=end,
+        skip_if_not_due=True,
+    )
+
+
+def test_skip_if_not_due_false_never_skips():
+    end = datetime(2026, 8, 10, 12, 5, tzinfo=timezone.utc)
+    assert not should_skip_model_for_tick(
+        cron_expr="0 * * * *",
+        model_interval_minutes=60,
+        dag_tick_minutes=5,
+        data_interval_end=end,
+        skip_if_not_due=False,
+    )
+
+
+def test_not_due_skip_result_shape():
+    payload = not_due_skip_result("db.schema.model", "0 * * * *")
+    assert payload["status"] == "skipped"
+    assert payload["reason"] == "not_due"
+    assert payload["model"] == "db.schema.model"
+    assert payload["cron"] == "0 * * * *"


### PR DESCRIPTION
## Summary
- Default `generation.skip_if_not_due=True`: coarser models on a fine DAG tick return `skipped/not_due` **before** loading SQLMesh `Context`.
- Helpers: `should_skip_model_for_tick`, `interval_end_matches_cron`, `not_due_skip_result`.
- Wired in `create_tasks_in_dag`, static Python tasks, and dynamic DAG generation.
- Docs in AUTO_SCHEDULING.md; opt-out for break-glass.

Generic for any mixed-cadence SQLMesh+Airflow project (not org-specific).

## Test plan
- [x] `pytest tests/test_skip_if_not_due.py tests/test_config.py tests/test_utils.py`
- [ ] Publish `0.9.15` to PyPI after merge
- [ ] Bump COWM `requirements.txt` and deploy staging